### PR TITLE
feature:route menu add proc displayIsMenu

### DIFF
--- a/arco-design-pro-vite/src/components/menu/index.vue
+++ b/arco-design-pro-vite/src/components/menu/index.vue
@@ -39,6 +39,11 @@ export default defineComponent({
             return element;
           }
 
+          //route filter displayIsMenu false
+          element.children = element.children.filter(
+            (x) => x.meta?.displayIsMenu !== false
+          );
+
           // Associated child node
           const subItem = travel(element.children, layer);
           if (subItem.length) {
@@ -50,7 +55,7 @@ export default defineComponent({
             element.children = subItem;
             return element;
           }
-          return null;
+          return element;
         });
         return collector.filter(Boolean);
       }
@@ -69,7 +74,7 @@ export default defineComponent({
     watch(
       route,
       (newVal) => {
-        if (newVal.meta.requiresAuth) {
+        if (newVal.meta.requiresAuth && newVal.meta.displayIsMenu !== false) {
           const key = newVal.matched[2]?.name as string;
           selectedKey.value = [key];
         }

--- a/arco-design-pro-vite/src/router/typings.d.ts
+++ b/arco-design-pro-vite/src/router/typings.d.ts
@@ -10,5 +10,6 @@ declare module 'vue-router' {
     locale?: string;
     // menu select key
     menuSelectKey?: string;
+    displayIsMenu?: boolean;
   }
 }


### PR DESCRIPTION
<!--
  Thanks so much for your PR and contribution.
  
  Before submitting, please make sure to follow the Pull Request Guidelines: https://github.com/arco-design/arco-design-pro/blob/master/CONTRIBUTING.md
-->

增加路由中设置路由项不属于菜单属性

## Types of changes

<!-- What types of changes does this PR introduce -->
- [x] New feature
- [ ] Bug fix
- [ ] Documentation change
- [ ] Coding style change
- [ ] Refactoring
- [ ] Performance improvement
- [ ] Test cases
- [ ] Continuous integration
- [ ] Typescript definition change
- [ ] Breaking change

## Background and context

当路由项地址不属于菜单项目时的属性配置

## Solution
增加displayInMenu属性
过滤不作为菜单路由

## How is the change tested?
测试应用与不应用时的页面菜单栏显示
router/modules/test.ts
meta: {
        displayIsMenu: false,
      },