### PR TITLE
fix: find menu open keys

### DIFF
--- a/arco-design-pro-vite/src/components/menu/index.vue
+++ b/arco-design-pro-vite/src/components/menu/index.vue
@@ -47,28 +47,24 @@
           name: item.name,
         });
       };
-      const findMenuOpenKeys = (name: string) => {
+      const findMenuOpenKeys = (target: string) => {
         const result: string[] = [];
         let isFind = false;
-        const backtrack = (
-          item: RouteRecordRaw,
-          keys: string[],
-          target: string
-        ) => {
+        const backtrack = (item: RouteRecordRaw, keys: string[]) => {
           if (item.name === target) {
             isFind = true;
-            result.push(...keys, item.name as string);
+            result.push(...keys);
             return;
           }
           if (item.children?.length) {
             item.children.forEach((el) => {
-              backtrack(el, [...keys], target);
+              backtrack(el, [...keys, el.name as string]);
             });
           }
         };
         menuTree.value.forEach((el: RouteRecordRaw) => {
           if (isFind) return; // Performance optimization
-          backtrack(el, [el.name as string], name);
+          backtrack(el, [el.name as string]);
         });
         return result;
       };


### PR DESCRIPTION
<!--
  Thanks so much for your PR and contribution.
  
  Before submitting, please make sure to follow the Pull Request Guidelines: https://github.com/arco-design/arco-design-pro/blob/master/CONTRIBUTING.md
-->

<!-- Put an `x` in "[ ]" to check a box) -->

## Types of changes

<!-- What types of changes does this PR introduce -->
- [ ] New feature
- [x] Bug fix
- [ ] Documentation change
- [ ] Coding style change
- [ ] Refactoring
- [ ] Performance improvement
- [ ] Test cases
- [ ] Continuous integration
- [ ] Typescript definition change
- [ ] Breaking change

## Background and context

我现在有一个三级菜单 C（A/B/C），点击我的三级菜单后，A 展开了，但是 B 并没有展开，debug了一下发现这个函数 findMenuOpenKeys 只返回了 [ A ]，预期应该返回 [A, B] 。经过修改，已经达到预期。


<!-- Explain what problem does the PR solve -->
<!-- Link to related open issues if applicable -->

## Solution

<!-- Describe how the problem is fixed in detail -->

## How is the change tested?

<!-- Unit tests should be added/updated for bug fixes and new features, if applicable -->
<!-- Please describe how you tested the change. E.g. Creating/updating unit tests or attaching a screenshot of how it works with your change -->

## Changelog

| Changelog(CN) | Changelog(EN) | Related issues | 
| ------------- | ------------- | -------------- |
|               |               |                |

## Checklist:

- [ ] Provide changelog for relevant changes (e.g. bug fixes and new features) if applicable.
- [ ] Changes are submitted to the appropriate branch (e.g. features should be submitted to `feature` branch and others should be submitted to `master` branch)

## Other information

<!-- Please describe what other information that should be taken care of. E.g. describe the impact if introduce a breaking change -->