### PR TITLE
Fix: Build issues

### DIFF
--- a/arco-design-pro-vite/tsconfig.json
+++ b/arco-design-pro-vite/tsconfig.json
@@ -5,6 +5,7 @@
     "moduleResolution": "node",
     "strict": true,
     "jsx": "preserve",
+    "jsxImportSource": "vue",
     "sourceMap": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,


### PR DESCRIPTION
jsx support causes "npm run build" to error
```
src/components/menu/index.vue:102:19 - error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
```


Related Links https://cn.vuejs.org/guide/extras/render-function.html#jsx-type-inference